### PR TITLE
enhanse that forcing topics to be in the 2dn line of header

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -158,6 +158,10 @@
 	display: inline-flex;
 }
 
+.Header .nav-container--independent {
+	width: 100%;
+}
+
 .Header .ui.menu .item.nav-item  {
 	width: 80px;
 	padding: 17px 2px;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -33,7 +33,6 @@ export default class Header extends Component {
   componentDidMount() {
     this._getHeaderHeight()
     window.addEventListener('resize', this._getHeaderHeight)
-
     // detect sroll position
     window.addEventListener('scroll', this._handleScroll)
   }
@@ -146,7 +145,6 @@ export default class Header extends Component {
 
   render() {
     const { sectionList, topics } = this.props
-
     let itemsForHeader = {}
     itemsForHeader.topics = []
     itemsForHeader.sections = []
@@ -216,7 +214,7 @@ export default class Header extends Component {
                   )
                 })}
               </div>
-              <div className="nav-container">
+              <div className="nav-container nav-container--independent " >
                 { _.map(itemsForHeader.topics, (i)=>{
                   return (
                     <a href={'/topic/' + i.id} key={i.id} className="item nav-item" onClick={ this._handleClick }>{i.name}</a>
@@ -230,6 +228,10 @@ export default class Header extends Component {
       </div>
     )
   }
+}
+
+Header.contextTypes = {
+  device: React.PropTypes.string
 }
 
 export { Header }


### PR DESCRIPTION
in the ex-version, the topics are not really be put in the second line if the first line's width is too short enough to fit the topics